### PR TITLE
Overload shouldAnimate to disable animations on android

### DIFF
--- a/lib/components/victory-pie.js
+++ b/lib/components/victory-pie.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { G } from "react-native-svg";
+import { Platform } from "react-native";
 import { VictoryLabel, VictoryContainer, NativeHelpers, Slice} from "victory-core-native";
 import { VictoryPie } from "victory-pie/src";
 
@@ -20,5 +21,9 @@ export default class extends VictoryPie {
       Object.assign({ role: "presentation", x, y }, nativeStyle),
       children
     );
+  }
+
+  shouldAnimate() {
+    return (Platform.OS === "android") ? false : Boolean(this.props.animate);
   }
 }


### PR DESCRIPTION
Achieves the same as https://github.com/FormidableLabs/victory-chart-native/pull/23 for pies
